### PR TITLE
Madninja/footprint

### DIFF
--- a/examples/Basic/platformio.ini
+++ b/examples/Basic/platformio.ini
@@ -15,4 +15,4 @@ src_dir=.
 platform = atmelavr
 board = uno
 framework = arduino
-lib_deps = Helium@>=1.0.1
+lib_deps = Helium

--- a/examples/Basic/platformio.ini
+++ b/examples/Basic/platformio.ini
@@ -15,4 +15,4 @@ src_dir=.
 platform = atmelavr
 board = uno
 framework = arduino
-lib_deps = Helium
+lib_deps = https://github.com/helium/helium-arduino#2aed296 

--- a/examples/Basic/platformio.ini
+++ b/examples/Basic/platformio.ini
@@ -15,4 +15,4 @@ src_dir=.
 platform = atmelavr
 board = uno
 framework = arduino
-lib_deps = https://github.com/helium/helium-arduino#2aed296 
+lib_deps = Helium=../../src 

--- a/examples/Config/platformio.ini
+++ b/examples/Config/platformio.ini
@@ -16,4 +16,4 @@ platform = atmelavr
 board = uno
 framework = arduino
 build_flags = -D DEBUG=1
-lib_deps = Helium@>=1.0.1
+lib_deps = Helium=../../src

--- a/src/Helium.cpp
+++ b/src/Helium.cpp
@@ -375,9 +375,9 @@ Config::_set(const char *            config_key,
 }
 
 bool
-Config::is_stale()
+Config::is_stale(uint32_t retries)
 {
     bool result = false;
-    helium_config_poll_invalidate(&_ctx, &result, 0);
+    helium_config_poll_invalidate(&_ctx, &result, retries);
     return result;
 }

--- a/src/Helium.cpp
+++ b/src/Helium.cpp
@@ -138,31 +138,37 @@ Helium::reset()
 // Channel
 //
 
-Channel::Channel(Helium * aHelium)
+Channel::Channel(Helium * helium)
 {
-    helium = aHelium;
+    this->helium = helium;
+    helium_channel_init(&_ctx, &helium->_ctx, (uint8_t)-1);
 }
 
 int
 Channel::begin(const char * name, uint16_t * token)
 {
-    return helium_channel_create(&helium->_ctx, name, strlen(name), token);
+    return helium_create_channel(_ctx.helium, name, strlen(name), token);
 }
 
 int
 Channel::begin(const char * name, int8_t * result)
 {
     uint16_t token;
+    int8_t   response;
     int      status = begin(name, &token);
-    _channel_id     = -1;
     if (helium_status_OK == status)
     {
-        status = poll_result(token, &_channel_id);
+        status = poll_result(token, &response);
+    }
+
+    if (helium_status_OK == status && response > 0)
+    {
+        _ctx.channel_id = (uint8_t)response;
     }
 
     if (result)
     {
-        *result = status == helium_status_OK && _channel_id > 0 ? 0 : _channel_id;
+        *result = response > 0 ? 0 : response;
     }
 
     return status;
@@ -171,7 +177,7 @@ Channel::begin(const char * name, int8_t * result)
 int
 Channel::send(void const * data, size_t len, uint16_t * token)
 {
-    return helium_channel_send(&helium->_ctx, _channel_id, data, len, token);
+    return helium_channel_send(&_ctx, data, len, token);
 }
 
 
@@ -190,18 +196,13 @@ Channel::send(void const * data, size_t len, int8_t * result)
 int
 Channel::poll_result(uint16_t token, int8_t * result, uint32_t retries)
 {
-    return helium_channel_poll_result(&helium->_ctx, token, result, retries);
+    return helium_poll_result(_ctx.helium, token, result, retries);
 }
 
 int
 Channel::poll_data(void * data, size_t len, size_t * used, uint32_t retries)
 {
-    return helium_channel_poll_data(&helium->_ctx,
-                                    _channel_id,
-                                    data,
-                                    len,
-                                    used,
-                                    retries);
+    return helium_channel_poll_data(&_ctx, data, len, used, retries);
 }
 
 //
@@ -210,16 +211,13 @@ Channel::poll_data(void * data, size_t len, size_t * used, uint32_t retries)
 
 Config::Config(Channel * channel)
 {
-    _channel = channel;
+    helium_config_init(&_ctx, &channel->_ctx);
 }
 
 int
 Config::get(const char * key, uint16_t * token)
 {
-    return helium_channel_config_get(&_channel->helium->_ctx,
-                                     _channel->_channel_id,
-                                     key,
-                                     token);
+    return helium_config_get(&_ctx, key, token);
 }
 
 
@@ -228,8 +226,6 @@ Config::_get(const char *            config_key,
              enum helium_config_type config_type,
              void *                  value,
              size_t                  value_len,
-             void *                  default_value,
-             size_t                  default_value_len,
              uint32_t                retries)
 {
     uint16_t token;
@@ -237,15 +233,8 @@ Config::_get(const char *            config_key,
     int8_t   result = 0;
     if (helium_status_OK == status)
     {
-        status = poll_get_result(token,
-                                 config_key,
-                                 config_type,
-                                 value,
-                                 value_len,
-                                 default_value,
-                                 default_value_len,
-                                 &result,
-                                 retries);
+        status = poll_get_result(
+            token, config_key, config_type, value, value_len, &result, retries);
     }
     if (helium_status_OK == status && result != 0)
     {
@@ -271,10 +260,6 @@ struct _poll_get_context
     void * dest;
     //! The length of the destination buffer
     size_t dest_len;
-    //! The default value. Assumed to be the same type as filter_type
-    void * default_value;
-    //! The length of the default_value
-    size_t default_value_len;
     //! The result status of the result handler
     enum config_poll_get_status status;
 };
@@ -295,7 +280,7 @@ _poll_get_result_handler(void *                  handler_ctx,
         // Not the right key, keep going
         return true;
     }
-    if (value_type == ctx->filter_type)
+    else if (value_type == ctx->filter_type)
     {
         // Found and the right type
         // Use the given value and the destination buffer size
@@ -305,13 +290,7 @@ _poll_get_result_handler(void *                  handler_ctx,
     {
         // Found but not the right type, return an error
         ctx->status = config_status_POLL_ERR_TYPE;
-        // And use the context's default
-        value_type = ctx->filter_type;
-        // Us the default value as the source
-        src = ctx->default_value;
-        // Check for a shorter default value length (only really valid for
-        // strings)
-        len = len > ctx->default_value_len ? ctx->default_value_len : len;
+        return false;
     }
 
     switch (value_type)
@@ -336,26 +315,22 @@ Config::poll_get_result(uint16_t           token,
                         helium_config_type config_type,
                         void *             value,
                         size_t             value_len,
-                        void *             default_value,
-                        size_t             default_value_len,
                         int8_t *           result,
                         uint32_t           retries)
 {
     struct _poll_get_context handler_ctx = {
-        .filter_key        = config_key,
-        .filter_type       = config_type,
-        .dest              = value,
-        .dest_len          = value_len,
-        .default_value     = default_value,
-        .default_value_len = default_value_len,
-        .status            = config_status_POLL_FOUND_NULL,
+        .filter_key  = config_key,
+        .filter_type = config_type,
+        .dest        = value,
+        .dest_len    = value_len,
+        .status      = config_status_POLL_FOUND_NULL,
     };
-    int status = helium_channel_config_get_poll_result(&_channel->helium->_ctx,
-                                                       token,
-                                                       _poll_get_result_handler,
-                                                       &handler_ctx,
-                                                       result,
-                                                       retries);
+    int status = helium_config_get_poll_result(&_ctx,
+                                               token,
+                                               _poll_get_result_handler,
+                                               &handler_ctx,
+                                               result,
+                                               retries);
     if (helium_status_OK == status)
     {
         status = handler_ctx.status;
@@ -370,21 +345,13 @@ Config::set(const char *       config_key,
             void *             value,
             uint16_t *         token)
 {
-    return helium_channel_config_set(&_channel->helium->_ctx,
-                                     _channel->_channel_id,
-                                     config_key,
-                                     config_type,
-                                     value,
-                                     token);
+    return helium_config_set(&_ctx, config_key, config_type, value, token);
 }
 
 int
 Config::poll_set_result(uint16_t token, int8_t * result, uint32_t retries)
 {
-    return helium_channel_config_set_poll_result(&_channel->helium->_ctx,
-                                                 token,
-                                                 result,
-                                                 retries);
+    return helium_config_set_poll_result(&_ctx, token, result, retries);
 }
 
 int
@@ -411,9 +378,6 @@ bool
 Config::is_stale()
 {
     bool result = false;
-    helium_channel_config_poll_invalidate(&_channel->helium->_ctx,
-                                          _channel->_channel_id,
-                                          &result,
-                                          0);
+    helium_config_poll_invalidate(&_ctx, &result, 0);
     return result;
 }

--- a/src/Helium.h
+++ b/src/Helium.h
@@ -555,10 +555,13 @@ class Config
      * When this returns true you should assume that any configuration
      * values you have previously retrieved are no longer valid.
      *
+     * @param retries The number of times to retry (optional). Defaults
+     *     to 0 since the common case is that staleness will be signaled
+     *     after a normal channel send has been performed.
      * @returns true if previous configuration values are stale, false
      *     if not
      */
-    bool is_stale();
+    bool is_stale(uint32_t retries = 0);
 
 
   private:

--- a/src/Helium.h
+++ b/src/Helium.h
@@ -245,11 +245,10 @@ class Channel
                   size_t * used,
                   uint32_t retries = HELIUM_POLL_RETRIES_5S);
 
-    /** The Helium Atom this channel uses to communicate. */
     Helium * helium;
 
   private:
-    int8_t _channel_id;
+    struct helium_channel _ctx;
 
     friend class Config;
 };
@@ -309,13 +308,12 @@ class Config
             int32_t      default_value,
             uint32_t     retries = HELIUM_POLL_RETRIES_5S)
     {
-        return _get(key,
-                    helium_config_i32,
-                    value,
-                    sizeof(*value),
-                    &default_value,
-                    sizeof(default_value),
-                    retries);
+        int status = _get(key, helium_config_i32, value, sizeof(*value), retries);
+        if (status != config_status_POLL_FOUND)
+        {
+            *value = default_value;
+        }
+        return status;
     }
 
     /** Get a float configuration value
@@ -333,13 +331,12 @@ class Config
             float        default_value,
             uint32_t     retries = HELIUM_POLL_RETRIES_5S)
     {
-        return _get(key,
-                    helium_config_f32,
-                    value,
-                    sizeof(*value),
-                    &default_value,
-                    sizeof(default_value),
-                    retries);
+        int status = _get(key, helium_config_f32, value, sizeof(*value), retries);
+        if (status != config_status_POLL_FOUND)
+        {
+            *value = default_value;
+        }
+        return status;
     }
 
 
@@ -358,13 +355,13 @@ class Config
             bool         default_value,
             uint32_t     retries = HELIUM_POLL_RETRIES_5S)
     {
-        return _get(key,
-                    helium_config_bool,
-                    value,
-                    sizeof(*value),
-                    &default_value,
-                    sizeof(default_value),
-                    retries);
+        int status =
+            _get(key, helium_config_bool, value, sizeof(*value), retries);
+        if (status != config_status_POLL_FOUND)
+        {
+            *value = default_value;
+        }
+        return status;
     }
 
     /** Get a string configuration value
@@ -385,16 +382,15 @@ class Config
             char *       value,
             size_t       value_len,
             char *       default_value,
-            size_t       default_value_len,
             uint32_t     retries = HELIUM_POLL_RETRIES_5S)
     {
-        return _get(key,
-                    helium_config_str,
-                    value,
-                    value_len,
-                    default_value,
-                    default_value_len,
-                    retries);
+        int status = _get(key, helium_config_str, value, value_len, retries);
+        if (status != config_status_POLL_FOUND && default_value)
+        {
+            (void)strncpy(value, default_value, value_len - 1);
+            value[value_len - 1] = '\0';
+        }
+        return status;
     }
 
     /** Send a request for a configuration value.
@@ -439,8 +435,6 @@ class Config
                         enum helium_config_type config_type,
                         void *                  value,
                         size_t                  value_len,
-                        void *                  default_value,
-                        size_t                  default_value_len,
                         int8_t *                result,
                         uint32_t retries = HELIUM_POLL_RETRIES_5S);
 
@@ -568,18 +562,17 @@ class Config
 
 
   private:
-    int       _get(const char *            config_key,
-                   enum helium_config_type config_type,
-                   void *                  value,
-                   size_t                  value_len,
-                   void *                  default_value,
-                   size_t                  default_value_len,
-                   uint32_t                retries);
-    int       _set(const char *            config_key,
-                   enum helium_config_type value_type,
-                   void *                  value,
-                   uint32_t                retries);
-    Channel * _channel;
+    int _get(const char *            config_key,
+             enum helium_config_type config_type,
+             void *                  value,
+             size_t                  value_len,
+             uint32_t                retries);
+    int _set(const char *            config_key,
+             enum helium_config_type value_type,
+             void *                  value,
+             uint32_t                retries);
+
+    struct helium_config _ctx;
 };
 
 #endif // HELIUM_H

--- a/src/HeliumUtil.cpp
+++ b/src/HeliumUtil.cpp
@@ -12,17 +12,17 @@ report_status(int status, int result)
     {
         if (result == 0)
         {
-            DBG_PRINTLN(F("Success"));
+            DBG_PRINTLN(F("S"));
         }
         else
         {
-            DBG_PRINT(F("FailR - "));
+            DBG_PRINT(F("FR-"));
             DBG_PRINTLN(result);
         }
     }
     else
     {
-        DBG_PRINT(F("FailS - "));
+        DBG_PRINT(F("FS-"));
         DBG_PRINTLN(status);
     }
     return status;
@@ -34,7 +34,7 @@ helium_connect(Helium * helium)
 {
     while (!helium->connected())
     {
-        DBG_PRINT(F("Connect - "));
+        DBG_PRINT(F("Co-"));
         int status = helium->connect();
         if (report_status(status) != helium_status_OK)
         {
@@ -52,7 +52,7 @@ channel_create(Channel * channel, const char * channel_name)
     {
         // Ensure we're connected
         helium_connect(channel->helium);
-        DBG_PRINT(F("Channel - "));
+        DBG_PRINT(F("Ch-"));
         status = channel->begin(channel_name, &result);
         // Print status and result
         if (report_status(status, result) != helium_status_OK)
@@ -74,7 +74,7 @@ channel_send(Channel *    channel,
     do
     {
         // Try to send
-        DBG_PRINT(F("Send - "));
+        DBG_PRINT(F("Sd-"));
         status = channel->send(data, len, &result);
         report_status(status, result);
         // Create the channel if any service errors are returned

--- a/src/HeliumUtil.cpp
+++ b/src/HeliumUtil.cpp
@@ -12,17 +12,18 @@ report_status(int status, int result)
     {
         if (result == 0)
         {
-            DBG_PRINTLN(F("Succeeded"));
+            DBG_PRINTLN(F("Success"));
         }
         else
         {
-            DBG_PRINT(F("Failed - "));
+            DBG_PRINT(F("FailR - "));
             DBG_PRINTLN(result);
         }
     }
     else
     {
-        DBG_PRINTLN("Failed");
+        DBG_PRINT(F("FailS - "));
+        DBG_PRINTLN(status);
     }
     return status;
 }
@@ -33,7 +34,7 @@ helium_connect(Helium * helium)
 {
     while (!helium->connected())
     {
-        DBG_PRINT(F("Connecting - "));
+        DBG_PRINT(F("Connect - "));
         int status = helium->connect();
         if (report_status(status) != helium_status_OK)
         {
@@ -51,7 +52,7 @@ channel_create(Channel * channel, const char * channel_name)
     {
         // Ensure we're connected
         helium_connect(channel->helium);
-        DBG_PRINT(F("Creating Channel - "));
+        DBG_PRINT(F("Channel - "));
         status = channel->begin(channel_name, &result);
         // Print status and result
         if (report_status(status, result) != helium_status_OK)
@@ -73,7 +74,7 @@ channel_send(Channel *    channel,
     do
     {
         // Try to send
-        DBG_PRINT(F("Sending - "));
+        DBG_PRINT(F("Send - "));
         status = channel->send(data, len, &result);
         report_status(status, result);
         // Create the channel if any service errors are returned

--- a/src/helium-client/helium-client.c
+++ b/src/helium-client/helium-client.c
@@ -716,7 +716,7 @@ helium_channel_send(struct helium_channel * channel,
 
 
 #define CHANNEL_PING 0x09
-#define CHANNEL_PONG 0x10
+#define CHANNEL_PONG 0x0A
 
 int
 helium_channel_ping(struct helium_channel * channel, uint16_t * token)

--- a/src/helium-client/helium-client.c
+++ b/src/helium-client/helium-client.c
@@ -716,12 +716,17 @@ helium_channel_send(struct helium_channel * channel,
 
 
 #define CHANNEL_PING 0x09
-#define CHANNEL_PONG 0x0A
+#define CHANNEL_PING_RESULT 0x0A
 
 int
 helium_channel_ping(struct helium_channel * channel, uint16_t * token)
 {
-    return _helium_channel_send(channel, CHANNEL_PING, 0, NULL, 0, token);
+    return _helium_channel_send(channel,
+                                CHANNEL_PING,
+                                CHANNEL_PING_RESULT,
+                                NULL,
+                                0,
+                                token);
 }
 
 
@@ -941,11 +946,10 @@ helium_config_get_poll_result(struct helium_config * config,
         return helium_status_ERR_CODING;
     }
 
-    int8_t err;
+    int8_t err = 0;
     switch (cmd->get.res._tag)
     {
     case cmd_config_get_res_tag_res:
-        err = 0;
         break;
     case cmd_config_get_res_tag_err:
         err = cmd->get.res.err;
@@ -972,7 +976,7 @@ helium_config_get_poll_result(struct helium_config * config,
         char key[VECTOR_MAX_LEN_key + 1];
         _decode_config_key(&assoc->k, key);
 
-        enum helium_config_type value_type;
+        enum helium_config_type value_type = helium_config_null;
         _decode_config_value(&assoc->v, &value_type, (char *)config->buf);
 
         if (!handler(handler_ctx, key, value_type, config->buf))
@@ -1035,11 +1039,10 @@ helium_config_set_poll_result(struct helium_config * config,
         return helium_status_ERR_CODING;
     }
 
-    int8_t err;
+    int8_t err = 0;
     switch (cmd->set.res._tag)
     {
     case cmd_config_set_res_tag_res:
-        err = 0;
         break;
     case cmd_config_set_res_tag_err:
         err = cmd->set.res.err;

--- a/src/helium-client/helium-client.c
+++ b/src/helium-client/helium-client.c
@@ -616,7 +616,7 @@ helium_channel_init(struct helium_channel * channel,
                     struct helium_ctx *     helium,
                     uint8_t                 channel_id)
 {
-    channel->helium = helium;
+    channel->helium     = helium;
     channel->channel_id = channel_id;
 }
 
@@ -634,9 +634,7 @@ _helium_channel_poll_data(struct helium_channel * channel,
         helium_poll_token(channel->helium, token, data, len, used, 0);
     if (helium_poll_OK_NO_DATA == status && retries > 0)
     {
-        struct helium_channel poll_channel;
-        helium_channel_init(&poll_channel, channel->helium, 0);
-        helium_channel_send(&poll_channel, NULL, 0, NULL);
+        helium_channel_ping(channel, NULL);
         status =
             helium_poll_token(channel->helium, token, data, len, used, retries);
     }
@@ -717,13 +715,23 @@ helium_channel_send(struct helium_channel * channel,
 }
 
 
+#define CHANNEL_PING 0x09
+#define CHANNEL_PONG 0x10
+
+int
+helium_channel_ping(struct helium_channel * channel, uint16_t * token)
+{
+    return _helium_channel_send(channel, CHANNEL_PING, 0, NULL, 0, token);
+}
+
+
+
 //
 // Configuration
 //
 
 void
-helium_config_init(struct helium_config *  config,
-                   struct helium_channel * channel)
+helium_config_init(struct helium_config * config, struct helium_channel * channel)
 {
     config->channel = channel;
 }

--- a/src/helium-client/helium-client.h
+++ b/src/helium-client/helium-client.h
@@ -81,48 +81,64 @@ helium_reset(struct helium_ctx * ctx);
 int
 helium_poll(struct helium_ctx * ctx, void * data, const size_t len, size_t * used);
 
-//
-// Channel functions
-//
+int
+helium_poll_token(struct helium_ctx * ctx,
+                  uint16_t            token,
+                  void *              data,
+                  size_t              len,
+                  size_t *            used,
+                  uint32_t            retries);
 
 int
-helium_channel_poll_data(struct helium_ctx * ctx,
-                         uint8_t             channel_id,
-                         void *              data,
-                         size_t              len,
-                         size_t *            used,
-                         uint32_t            retries);
+helium_poll_result(struct helium_ctx * ctx,
+                   uint16_t            token,
+                   int8_t *            result,
+                   uint32_t            retries);
 
 int
-helium_channel_poll_token(struct helium_ctx * ctx,
-                          uint16_t            token,
-                          void *              data,
-                          size_t              len,
-                          size_t *            used,
-                          uint32_t            retries);
-
-int
-helium_channel_poll_result(struct helium_ctx * ctx,
-                           uint16_t            token,
-                           int8_t *            result,
-                           uint32_t            retries);
-
-int
-helium_channel_create(struct helium_ctx * ctx,
+helium_create_channel(struct helium_ctx * ctx,
                       const char *        name,
                       size_t              len,
                       uint16_t *          token);
 
+//
+// Channel functions
+//
+
+struct helium_channel
+{
+    struct helium_ctx * helium;
+    uint8_t             channel_id;
+};
+
+void
+helium_channel_init(struct helium_channel * channel,
+                    struct helium_ctx *     helium,
+                    uint8_t                 channel_id);
+
 int
-helium_channel_send(struct helium_ctx * ctx,
-                    uint8_t             channel_id,
-                    void const *        data,
-                    size_t              len,
-                    uint16_t *          token);
+helium_channel_poll_data(struct helium_channel * channel,
+                         void *                  data,
+                         size_t                  len,
+                         size_t *                used,
+                         uint32_t                retries);
+
+int
+helium_channel_send(struct helium_channel * channel,
+                    void const *            data,
+                    size_t                  len,
+                    uint16_t *              token);
 
 //
-// Channel Configuration
+// Configuration
 //
+
+struct helium_config
+{
+    struct helium_channel * channel;
+    struct cmd_config       cmd;
+    uint8_t                 buf[HELIUM_MAX_DATA_SIZE];
+};
 
 enum helium_config_type
 {
@@ -133,45 +149,46 @@ enum helium_config_type
     helium_config_null,
 };
 
-int
-helium_channel_config_get(struct helium_ctx * ctx,
-                          uint8_t             channel_id,
-                          const char *        config_key,
-                          uint16_t *          token);
-
-typedef bool (*helium_channel_config_handler)(void *       handler_ctx,
-                                              const char * key,
-                                              enum helium_config_type value_type,
-                                              void *                  value);
+void
+helium_config_init(struct helium_config *  config,
+                   struct helium_channel * channel);
 
 int
-helium_channel_config_get_poll_result(struct helium_ctx *           ctx,
-                                      uint16_t                      token,
-                                      helium_channel_config_handler handler,
-                                      void *                        handler_ctx,
-                                      int8_t *                      result,
-                                      uint32_t                      retries);
+helium_config_get(struct helium_config * config,
+                  const char *           config_key,
+                  uint16_t *             token);
+
+typedef bool (*helium_config_handler)(void *                  handler_ctx,
+                                      const char *            key,
+                                      enum helium_config_type value_type,
+                                      void *                  value);
+
+int
+helium_config_get_poll_result(struct helium_config * config,
+                              uint16_t               token,
+                              helium_config_handler  handler,
+                              void *                 handler_ctx,
+                              int8_t *               result,
+                              uint32_t               retries);
 
 
 int
-helium_channel_config_set(struct helium_ctx *     ctx,
-                          uint8_t                 channel_id,
-                          const char *            config_key,
-                          enum helium_config_type value_type,
-                          void *                  value,
-                          uint16_t *              token);
+helium_config_set(struct helium_config *  config,
+                  const char *            config_key,
+                  enum helium_config_type value_type,
+                  void *                  value,
+                  uint16_t *              token);
 
 int
-helium_channel_config_set_poll_result(struct helium_ctx * ctx,
-                                      uint16_t            token,
-                                      int8_t *            result,
-                                      uint32_t            retries);
+helium_config_set_poll_result(struct helium_config * config,
+                              uint16_t               token,
+                              int8_t *               result,
+                              uint32_t               retries);
 
 int
-helium_channel_config_poll_invalidate(struct helium_ctx * ctx,
-                                      uint8_t             channel_id,
-                                      bool *              result,
-                                      uint32_t            retries);
+helium_config_poll_invalidate(struct helium_config * config,
+                              bool *                 result,
+                              uint32_t               retries);
 
 //
 // Externally required functions

--- a/src/helium-client/helium-client.h
+++ b/src/helium-client/helium-client.h
@@ -129,6 +129,10 @@ helium_channel_send(struct helium_channel * channel,
                     size_t                  len,
                     uint16_t *              token);
 
+int
+helium_channel_ping(struct helium_channel * channel, uint16_t * token);
+
+
 //
 // Configuration
 //


### PR DESCRIPTION
Using new helium-client that should reduce the stack footprint of the library a bit. 

This also introduced helium-channel-ping to ping a specific channel. It's like a channel_send without actually pushing data to the channel. 