### PR TITLE
Added support for Arduino MEGA 2560

### DIFF
--- a/examples/Basic/Board.h
+++ b/examples/Basic/Board.h
@@ -12,6 +12,11 @@
 SoftwareSerial atom_serial(8, 9);
 #define HELIUM_BAUD_RATE helium_baud_b9600
 
+#elif defined(ARDUINO_AVR_MEGA2560)
+#include "SoftwareSerial.h"
+SoftwareSerial atom_serial(10, 11);
+#define HELIUM_BAUD_RATE helium_baud_b9600
+
 #elif defined(ARDUINO_SAM_ZERO)
 // Arduino M0 Pro
 #define atom_serial Serial5

--- a/examples/Config/Board.h
+++ b/examples/Config/Board.h
@@ -12,6 +12,11 @@
 SoftwareSerial atom_serial(8, 9);
 #define HELIUM_BAUD_RATE helium_baud_b9600
 
+#elif defined(ARDUINO_AVR_MEGA2560)
+#include "SoftwareSerial.h"
+SoftwareSerial atom_serial(10, 11);
+#define HELIUM_BAUD_RATE helium_baud_b9600
+
 #elif defined(ARDUINO_SAM_ZERO)
 // Arduino M0 Pro
 #define atom_serial Serial5

--- a/examples/Downlink/Board.h
+++ b/examples/Downlink/Board.h
@@ -12,6 +12,11 @@
 SoftwareSerial atom_serial(8, 9);
 #define HELIUM_BAUD_RATE helium_baud_b9600
 
+#elif defined(ARDUINO_AVR_MEGA2560)
+#include "SoftwareSerial.h"
+SoftwareSerial atom_serial(10, 11);
+#define HELIUM_BAUD_RATE helium_baud_b9600
+
 #elif defined(ARDUINO_SAM_ZERO)
 // Arduino M0 Pro
 #define atom_serial Serial5

--- a/examples/Soil_Humidity/Board.h
+++ b/examples/Soil_Humidity/Board.h
@@ -12,6 +12,11 @@
 SoftwareSerial atom_serial(8, 9);
 #define HELIUM_BAUD_RATE helium_baud_b9600
 
+#elif defined(ARDUINO_AVR_MEGA2560)
+#include "SoftwareSerial.h"
+SoftwareSerial atom_serial(10, 11);
+#define HELIUM_BAUD_RATE helium_baud_b9600
+
 #elif defined(ARDUINO_SAM_ZERO)
 // Arduino M0 Pro
 #define atom_serial Serial5

--- a/src/Helium.cpp
+++ b/src/Helium.cpp
@@ -52,17 +52,20 @@ Helium::Helium(HardwareSerial * serial)
     helium_init(&_ctx, (void *)serial);
 }
 
-#if defined(ARDUINO_AVR_UNO)
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_MEGA2560)
 Helium::Helium(SoftwareSerial * serial)
 {
     helium_init(&_ctx, (void *)serial);
 }
+
+
+
 #endif
 
 int
 Helium::begin(enum helium_baud baud)
 {
-#if defined(ARDUINO_AVR_UNO)
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_MEGA2560)
     SoftwareSerial * serial = (SoftwareSerial *)_ctx.param;
 #else
     HardwareSerial * serial = (HardwareSerial *)_ctx.param;

--- a/src/Helium.h
+++ b/src/Helium.h
@@ -9,7 +9,7 @@
 #include "Arduino.h"
 #include "helium-client/helium-client.h"
 
-#if defined(ARDUINO_AVR_UNO)
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_MEGA2560)
 #include <SoftwareSerial.h>
 #endif
 
@@ -34,7 +34,7 @@ class Helium
      */
     Helium(HardwareSerial * serial);
 
-#if defined(ARDUINO_AVR_UNO)
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_MEGA2560)
     /** Create a Helium instance on a software serial port
      *
      * @note SoftwareSerial is only exposed for the Arduino UNO.


### PR DESCRIPTION
Added what I changed to my local version of the library to support the Arduino MEGA 2560 with the Arduino expansion board for the Atom. Jumpers moved to bottom/middle pins on 11, middle/top pins on 10.